### PR TITLE
Write 'generated_from.json'

### DIFF
--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -17,13 +17,13 @@ module Kennel
         end
       end
 
-      def validated_parts
+      def validated_parts(base_dir)
         all = parts
         unless all.is_a?(Array) && all.all? { |part| part.is_a?(Record) }
           invalid! "#parts must return an array of Records"
         end
 
-        all.each { |part| part.strip_caller(here) }
+        all.each { |part| part.strip_caller(base_dir) }
         validate_parts(all)
         all
       end

--- a/lib/kennel/models/project.rb
+++ b/lib/kennel/models/project.rb
@@ -23,6 +23,7 @@ module Kennel
           invalid! "#parts must return an array of Records"
         end
 
+        all.each { |part| part.strip_caller(here) }
         validate_parts(all)
         all
       end

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -67,7 +67,7 @@ module Kennel
 
       def strip_caller(base_dir)
         @constructed_from = @constructed_from.map do |f|
-          f.sub(base_dir, '.') if f.start_with?(base_dir)
+          f.sub(base_dir, '.') if f.start_with?(base_dir + '/')
         end.compact
       end
 

--- a/lib/kennel/models/record.rb
+++ b/lib/kennel/models/record.rb
@@ -67,14 +67,14 @@ module Kennel
 
       def strip_caller(base_dir)
         @constructed_from = @constructed_from.map do |f|
-          f.sub(base_dir, '.') if f.start_with?(base_dir + '/')
+          f.sub(base_dir, ".") if f.start_with?(base_dir + "/")
         end.compact
       end
 
       def generated_from
         @generated_from ||= begin
           frames = constructed_from.map do |frame|
-            file, line, = frame.split(':')
+            file, line, = frame.split(":")
             "#{file}:#{line}"
           end
 

--- a/test/kennel/models/project_test.rb
+++ b/test/kennel/models/project_test.rb
@@ -64,7 +64,7 @@ describe Kennel::Models::Project do
 
   describe "#validated_parts" do
     it "returns parts" do
-      TestProject.new.validated_parts.size.must_equal 0
+      TestProject.new.validated_parts(Dir.pwd).size.must_equal 0
     end
 
     it "raises an error if parts did not return an array" do
@@ -72,7 +72,7 @@ describe Kennel::Models::Project do
         Kennel::Models::Monitor.new(self)
       })
       validation_error_message do
-        bad_project.validated_parts
+        bad_project.validated_parts(Dir.pwd)
       end.must_equal "test_project #parts must return an array of Records"
     end
   end

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -165,6 +165,17 @@ describe Kennel::Models::Record do
     end
   end
 
+  describe "strip_caller / generated_from" do
+    it "calls" do
+      record = eval <<~EVAL, nil, "/some/file1.rb", 777
+        eval 'TestRecord.new(TestProject.new)', nil, "/another/file2.rb", 888
+      EVAL
+      record.strip_caller('/some')
+      answer = record.generated_from
+      answer.must_equal ["./file1.rb:777"]
+    end
+  end
+
   describe ".ignore_default" do
     it "ignores defaults" do
       a = { a: 1 }

--- a/test/kennel/models/record_test.rb
+++ b/test/kennel/models/record_test.rb
@@ -170,7 +170,7 @@ describe Kennel::Models::Record do
       record = eval <<~EVAL, nil, "/some/file1.rb", 777
         eval 'TestRecord.new(TestProject.new)', nil, "/another/file2.rb", 888
       EVAL
-      record.strip_caller('/some')
+      record.strip_caller("/some")
       answer = record.generated_from
       answer.must_equal ["./file1.rb:777"]
     end

--- a/test/kennel/settings_as_methods_test.rb
+++ b/test/kennel/settings_as_methods_test.rb
@@ -61,15 +61,16 @@ describe Kennel::SettingsAsMethods do
     end
 
     it "stores invocation_location from first outside project line" do
-      Kennel::Models::Monitor.any_instance.expects(:caller).returns(
+      my_class = Class.new(Kennel::Models::Monitor)
+      my_class.define_method(:caller) do
         [
-          "/foo/bar.rb",
-          "#{Dir.pwd}/baz.rb"
+          "/foo/bar.rb:555:in c",
+          "#{Dir.pwd}/baz.rb:666:in d"
         ]
-      )
-      model = Kennel::Models::Monitor.new(TestProject.new)
-      location = model.instance_variable_get(:@invocation_location).sub(/:\d+/, ":123")
-      location.must_equal "baz.rb"
+      end
+      model = my_class.new(TestProject.new)
+      location = model.instance_variable_get(:@invocation_location)
+      location.must_equal "baz.rb:666:in d"
     end
   end
 


### PR DESCRIPTION
No tests yet to prove that 'generated_from.json' is actually written / contains the right stuff.

Rationale:

- make it easy (quick lookup in a json map) to find where a particular part comes from
- make it accurate & detailed (include line numbers)
- however, including line numbers will mean that this data will churn more

But where to put this data?

We could put it into the monitor etc. message (i.e part of the `Managed by kennel` line). Pro: easily available from datadog. Con: Line number changes especially in `./parts` could cause a _lot_ of objects to be updated. Con: probably a bit wordy / ugly to put into the message.

We could write it into the existing `generated` files. Pro: easily available from codebase; helps data analysis. Con: high-churn data makes PRs bigger and messier.

We could write it into a _new_ place in `generated`. Pro: easily available from codebase; helps data analysis. Pro: one never really has to _review_ this new file in PRs. Con: might lead to more merge conflicts, for branches which touch alphabetically-neighbouring / -overlapping kennel IDs.

This PR chooses the third option.

(Partial) preview of what it looks like for zendesk:

```json
{
  "obviously there are a lot more records in the real dataset": [],
  "zoas:sqs-job-processing-time-v2": [
    "./projects/zoas.rb:400",
    "./projects/zoas.rb:27"
  ],
  "zoas:sqs-job-processing-time-v2-slo": [
    "./extensions/monitor_with_slo.rb:12",
    "./projects/zoas.rb:421",
    "./projects/zoas.rb:27"
  ],
  "zoas:zoas": [
    "./projects/zoas.rb:6"
  ],
  "zoas:zoas-jobs-dead-production.fifo-has-messages-in-the-queue": [
    "./projects/zoas.rb:317",
    "./projects/zoas.rb:24"
  ]
}
```
